### PR TITLE
CO-109: Add the cake maven resolver to sbt.repositories when Nexus server was setup

### DIFF
--- a/sbt.repositories
+++ b/sbt.repositories
@@ -1,6 +1,4 @@
 [repositories]
   local
-  # TODO: CO-109 The following resolvers should be changed to a cake maven resolver
-  maven-central
-  typesafe-ivy: http://repo.typesafe.com/typesafe/ivy-releases/, [organization]/[module]/(scala_[scalaVersion]/)(sbt_[sbtVersion]/)[revision]/[type]s/[artifact](-[classifier]).[ext]
-  sbt-bintray: https://dl.bintray.com/sbt/sbt-plugin-releases/, [organization]/[module]/(scala_[scalaVersion]/)(sbt_[sbtVersion]/)[revision]/[type]s/[artifact](-[classifier]).[ext]
+  ivy-cake-releases: http://nexus.cakesolutions.eu:8081/nexus/content/groups/cake-releases/, [organization]/[module]/(scala_[scalaVersion]/)(sbt_[sbtVersion]/)[revision]/[type]s/[artifact](-[classifier]).[ext]
+  maven-cake-releases: http://nexus.cakesolutions.eu:8081/nexus/content/groups/cake-releases/


### PR DESCRIPTION
- [x] Add Cake Nexus resolvers
- [x] Ensure resolvers work in local dev environments
- [ ] Ensure Jenkins is able to use resolvers (depends on https://cakesolutions.jira.com/browse/CO-39)
---
- [ ] Ready for review