### PR TITLE
NO-TICKET: dockerPublishTags SettingKey

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,6 +191,10 @@ Docker container version number may be specified at the SBT command line by sett
 The following configuration settings can be modified in projects that enable this plugin:
 * `dockerRepository` (set to the value of `DOCKER_REPOSITORY` or the project name) - used to define where the container
   will be published
+  
+The following configuration settings can be modified in projects that enable this plugin:
+* `dockerPublishTags`  (empty by default) - allows extra tags to be added to the docker:publish other than 
+`latest` and `version`. 
 
 ### SBT Tasks
 

--- a/src/main/scala/net/cakesolutions/CakeDockerPlugin.scala
+++ b/src/main/scala/net/cakesolutions/CakeDockerPlugin.scala
@@ -42,6 +42,12 @@ object CakeDockerPlugin extends AutoPlugin {
     packageName in Docker := name.value,
     maintainer in Docker := "Cake Solutions <devops@cakesolutions.net>",
     version in Docker := sys.props.get("tag").getOrElse(version.value),
+    dockerPublishTags := Seq(),
+    dockerBuildOptions ++= {
+      val alias = dockerAlias.value
+      dockerPublishTags.value
+        .flatMap(tag => List("-t", alias.copy(tag = Some(tag)).versioned))
+    },
     dockerCommands += {
       val dockerArgList =
         CakeBuildInfoKeys.generalInfo.value ++
@@ -100,5 +106,14 @@ object CakeDockerPluginKeys {
   val dockerRemove: TaskKey[Unit] =
     taskKey[Unit](
       "Runs `docker rmi -f <ids>` for the images associated to the scope"
+    )
+
+  /**
+    * Setting key defining extra tags that will be added to the
+    * dockerBuildOptions
+    */
+  val dockerPublishTags: SettingKey[Seq[String]] =
+    settingKey[Seq[String]](
+      "Extra tags to publish other than version and latest"
     )
 }


### PR DESCRIPTION
dockerPublishTags is added for extra publish tags support.
See https://github.com/sbt/sbt-native-packager/issues/979

If you want to close publishing `latest`, just add `dockerUpdateLatest := false` to you project module in your `build.sbt`.