### PR TITLE
Wait for docker compose healthy task

### DIFF
--- a/README.md
+++ b/README.md
@@ -328,6 +328,7 @@ all containers reach to the healthy status
 The following SBT tasks are enabled:
 * `integrationTests` - runs integration tests within all docker operations and steps
 * `performanceTests` - runs performance tests within all docker operations and steps 
+* `healthCheckWait` - wait until docker services report healthy
 
 ## `CakePublishMavenPlugin`: Artifact Publishing
 

--- a/src/main/scala/net/cakesolutions/CakeTestRunnerPlugin.scala
+++ b/src/main/scala/net/cakesolutions/CakeTestRunnerPlugin.scala
@@ -47,7 +47,8 @@ object CakeTestRunnerPlugin extends AutoPlugin {
     healthCheckIntervalInSeconds := 5,
     healthCheckRetryCount := 5,
     integrationTests := integrationTestsTask.value,
-    performanceTests := performanceTestsTask.value
+    performanceTests := performanceTestsTask.value,
+    healthCheckWait := healthCheck.value
   )
 
   private def runIntegrationTests: Def.Initialize[Task[Unit]] = Def.taskDyn {
@@ -83,7 +84,7 @@ object CakeTestRunnerPlugin extends AutoPlugin {
     Def.sequential(
       checkDockerComposeVersion,
       dockerComposeUp,
-      healthCheck,
+      healthCheckWait,
       Def.taskDyn {
         testTask.doFinally {
           cleanStop.taskValue
@@ -157,6 +158,12 @@ object CakeTestRunnerKeys {
     */
   val performanceTests: TaskKey[Unit] =
     taskKey[Unit]("Runs performance tests with docker fleet management")
+
+  /**
+    * Task that waits until all docker services report healthy
+    */
+  val healthCheckWait: TaskKey[Unit] =
+    taskKey[Unit]("Wait until docker services report healthy")
 
   /**
     * Retries count for health check in docker-compose scope

--- a/src/main/scala/net/cakesolutions/CakeTestRunnerPlugin.scala
+++ b/src/main/scala/net/cakesolutions/CakeTestRunnerPlugin.scala
@@ -3,6 +3,8 @@
 
 package net.cakesolutions
 
+import scala.annotation.tailrec
+
 import io.gatling.sbt.GatlingKeys.GatlingIt
 import sbt.Keys._
 import sbt._
@@ -112,6 +114,7 @@ object CakeTestRunnerPlugin extends AutoPlugin {
 
     import scala.concurrent.duration._
 
+    @tailrec
     def check(rc: Int): Boolean = {
       val healthy =
         checkHealth(CakeDockerComposeKeys.dockerComposeFiles.value)(

--- a/src/sbt-test/sbt-cake/dockerhealth/build.sbt
+++ b/src/sbt-test/sbt-cake/dockerhealth/build.sbt
@@ -10,7 +10,8 @@ val dockerhealth = (project in file("."))
   .enablePlugins(
     AshScriptPlugin,
     CakeDockerPlugin,
-    CakeDockerHealthPlugin)
+    CakeDockerHealthPlugin,
+    CakeTestRunnerPlugin)
   .settings(
     libraryDependencies ++= Seq(
       Akka.Http.base,

--- a/src/sbt-test/sbt-cake/dockerhealth/test
+++ b/src/sbt-test/sbt-cake/dockerhealth/test
@@ -30,5 +30,17 @@ $ exec echo "- expect test to pass"
 #$ exists target/docker/docker_dockerhealth_1.log
 
 > dockerComposeDown
-
 > dockerRemove
+
+> dockerComposeUp
+
+$ exec echo "TEST: health check wait - containers launched"
+> dockerComposeUp
+
+$ exec echo "TEST: wait for docker health checks to respond healthy"
+> healthCheckWait
+> checkContainersHealth
+
+> dockerComposeDown
+> dockerRemove
+


### PR DESCRIPTION
Allows custom test runner composition by making the health check waiting task explicit. This means a user wouldn't need to go through the whole `integrationTests` task, which is quite heavyweight and takes a long time to run.